### PR TITLE
Don't panic on malformed packets in the reader (remote DoS)

### DIFF
--- a/coral-protocol/src/reader.rs
+++ b/coral-protocol/src/reader.rs
@@ -32,7 +32,10 @@ impl<'a> Reader<'a> {
     }
 
     pub fn read_bytes(&mut self, length: usize) -> Vec<u8> {
-        let end = self.position + length;
+        // length is attacker-controlled (from a VarInt on the wire); never read
+        // past the end of the buffer. Clamp to what is actually available, the
+        // same lenient behaviour read_byte and read_string already use.
+        let end = self.position.saturating_add(length).min(self.data.len());
         let bytes = self.data[self.position..end].to_vec();
         self.position = end;
         bytes
@@ -115,10 +118,9 @@ impl<'a> Reader<'a> {
         let string_bytes = &self.data[self.position..end];
         self.position = end;
 
-        match String::from_utf8(string_bytes.to_vec()) {
-            Ok(s) => s,
-            Err(e) => panic!("Invalid UTF-8 string: {}", e),
-        }
+        // Invalid UTF-8 from the wire must not crash the server; decode
+        // lossily instead of panicking.
+        String::from_utf8_lossy(string_bytes).into_owned()
     }
 
     pub fn read_long(&mut self) -> i64 {

--- a/coral-protocol/tests/reader_untrusted_input.rs
+++ b/coral-protocol/tests/reader_untrusted_input.rs
@@ -1,0 +1,33 @@
+// Regression: untrusted input in the packet reader must not crash the server.
+use coral_protocol::packets::PacketIn;
+use coral_protocol::packets::login::EncryptionResponse;
+use coral_protocol::reader::Reader;
+
+#[test]
+fn read_bytes_past_end_is_clamped_not_panics() {
+    let data = [0x01u8, 0x02, 0x03];
+    let mut reader = Reader::new(&data);
+    // A length far past the end must clamp to what is available, not panic.
+    let out = reader.read_bytes(1000);
+    assert_eq!(out, vec![0x01, 0x02, 0x03]);
+}
+
+#[test]
+fn read_string_invalid_utf8_is_lossy_not_panics() {
+    // A length-1 string with byte 0xFF is invalid UTF-8.
+    let data = [0x01u8, 0xFF];
+    let mut reader = Reader::new(&data);
+    let s = reader.read_string();
+    // Lossy decoding yields the replacement character, no panic.
+    assert_eq!(s, "\u{FFFD}");
+}
+
+#[test]
+fn encryption_response_decode_oversized_length_is_ok() {
+    // A malicious client sends an oversized secret length (VarInt 1000) with no
+    // following data. Decoding must not panic.
+    let mut buf = bytes::Bytes::from(vec![0xE8, 0x07]);
+    let decoded = EncryptionResponse::decode(&mut buf).expect("decode should not error");
+    // The clamped read yields an empty secret rather than crashing.
+    assert!(decoded.shared_secret.is_empty());
+}


### PR DESCRIPTION
## What

The packet `Reader` is fed bytes straight from the network, but two of its primitives crash the whole server on input a client fully controls.

**1. `read_bytes` sliced out of range.**

```rust
pub fn read_bytes(&mut self, length: usize) -> Vec<u8> {
    let end = self.position + length;
    let bytes = self.data[self.position..end].to_vec();  // panics if end > len
```

`length` comes from a VarInt on the wire. If it exceeds the payload, the slice panics with `range end index N out of range`. This is remotely reachable — `EncryptionResponse::decode` reads a VarInt secret length and hands it straight to `read_bytes`, so a **single crafted login packet aborts the server**:

```
thread '...' panicked at coral-protocol/src/reader.rs:36:
range end index 1002 out of range for slice of length 2
```

**2. `read_string` panicked on invalid UTF-8.**

```rust
Err(e) => panic!("Invalid UTF-8 string: {}", e),
```

A client can put non-UTF-8 bytes in any string field and crash the server.

## Fix

- `read_bytes` clamps `end` to the bytes actually available (using `saturating_add(...).min(len)`), matching the lenient behaviour `read_byte` and `read_string` already use past the end of the buffer.
- `read_string` decodes with `from_utf8_lossy` instead of panicking.

## Testing

Added `coral-protocol/tests/reader_untrusted_input.rs` covering all three:
- `read_bytes(1000)` on a 3-byte buffer clamps instead of panicking,
- `read_string` on invalid UTF-8 yields the replacement char,
- `EncryptionResponse::decode` on an oversized length returns `Ok` with an empty secret.

Verified RED→GREEN: before the fix each case panics (confirmed); after, all three pass. `cargo fmt` / `clippy` clean.

---
Note: this change was prepared with the help of an AI coding assistant; I reviewed it and verified the crashes and fixes locally.
